### PR TITLE
Add constellation rendering to map

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -16,9 +16,9 @@
 <body>
 <div id="viewer"></div>
 <div id="tooltip">
-    <div id="tooltip-header-left">The PRISM Network</div>
-    <div id="tooltip-header-right">Logistics Facility, Cunning 4</div>
-    <div id="tooltip-name">Party Machine</div>
+    <div id="tooltip-header-left">Sample Faction</div>
+    <div id="tooltip-header-right">Sample Asset Type, Stat #</div>
+    <div id="tooltip-name">Sample Asset</div>
     <div id="tooltip-system-info">
 
     </div>
@@ -100,18 +100,18 @@
     <div id="tooltip-system-objects"></div>
 </div>
 <div id="faction-info">
-    <div id="faction-info-header-left">New Unified Church of Humanity</div>
-    <div id="faction-info-header-right">0407 / Dega / Heces</div>
+    <div id="faction-info-header-left">Sample Faction</div>
+    <div id="faction-info-header-right">Hex / System / Planet</div>
 
     <div style="width: 550px; border-top: 1px dotted #444"></div>
 
-    <div class="faction-stat" id="faction-info-stat-force">3</div>
-    <div class="faction-stat" id="faction-info-stat-cunning">6</div>
-    <div class="faction-stat" id="faction-info-stat-wealth">5</div>
-    <div class="faction-stat" id="faction-info-stat-hp">29/29</div>
-    <div class="faction-stat" id="faction-info-stat-income">6</div>
-    <div class="faction-stat" id="faction-info-stat-balance">12</div>
-    <div class="faction-stat" id="faction-info-stat-xp">3</div>
+    <div class="faction-stat" id="faction-info-stat-force">Force Stat</div>
+    <div class="faction-stat" id="faction-info-stat-cunning">Cunning Stat</div>
+    <div class="faction-stat" id="faction-info-stat-wealth">Wealth Stat</div>
+    <div class="faction-stat" id="faction-info-stat-hp">Faction HP</div>
+    <div class="faction-stat" id="faction-info-stat-income">Faction Income</div>
+    <div class="faction-stat" id="faction-info-stat-balance">Faction FC balance</div>
+    <div class="faction-stat" id="faction-info-stat-xp">XP val</div>
     <div class="faction-label" id="faction-info-stat-force-label">Force</div>
     <div class="faction-label" id="faction-info-stat-cunning-label">Cunning</div>
     <div class="faction-label" id="faction-info-stat-wealth-label">Wealth</div>

--- a/html/index.html
+++ b/html/index.html
@@ -127,5 +127,17 @@
     <div id="faction-info-goal-desc"></div>
 </div>
 
+<div id="constellation-info">
+    <div id="constellation-info-header-left">Sample</div>
+    <div id="constellation-info-header-right">Sample</div>
+
+    <div style="width: 550px; border-top: 1px dotted #444"></div>
+
+    <div id="constellation-info-bonus-val">#</div>
+    <div id="constellation-info-bonus-label">Bonus</div>
+    <div id="constellation-info-hexes-label">Hexes</div>
+    <div id="constellation-info-hexes-val">Sample</div>
+</div>
+
 </body>
 </html>

--- a/html/scripts/classes.js
+++ b/html/scripts/classes.js
@@ -9,6 +9,7 @@ class Hex {
         this.x = pixel.x + this.w / 2;
         this.y = pixel.y + this.h / 2;
         this.vertices = hexVertices(this.x, this.y, this.w, this.h);
+        this.originalcolor = '#222222';
 
         // Render hex
         g
@@ -48,6 +49,10 @@ class Hex {
         this.hex.setAttribute('points', this.vertices);
         this.text.setAttribute('x', this.x);
         this.text.setAttribute('y', this.y + 0.45 * this.h);
+    }
+
+    changeOriginalColor(c){
+        this.originalcolor = c;
     }
 }
 
@@ -460,6 +465,7 @@ class Asset {
         });
     }
 
+
     replace() {
         this.container.childNodes.forEach(child => {
             if (child.classList.contains('hover')) {
@@ -477,4 +483,15 @@ class Asset {
             }
         });
     }
+}
+class Constellation{
+    constructor(constellationData) {
+        this.name = constellationData['Name'];
+        this.faction = constellationData['Faction']
+        this.bonus = constellationData['Bonus']
+        this.memberList = constellationData['Hex List'].split(',').sort();
+        this.memberListSpaces = constellationData['Hex List'].replaceAll(',',', ');
+        this.color = '#000000';
+    }
+        
 }

--- a/html/scripts/index.js
+++ b/html/scripts/index.js
@@ -24,6 +24,7 @@ function setVariables() {
     window.tipOn = false;
     window.tooltipTimeout = undefined;
     window.factionInfoTimeout = undefined;
+    window.constellationInfoTimeout = undefined;
     window.onmousemove = function(e) {
         let mouse_x = e.clientX;
         let mouse_y = e.clientY;

--- a/html/scripts/style.css
+++ b/html/scripts/style.css
@@ -254,6 +254,118 @@ mark {
     font-size: 14px;
 }
 
+
+#constellation-overview {
+    position: fixed;
+    top: 50%;
+    transform: translateY(-50%);
+    text-align: left;
+    color: #fff;
+    font-family: 'D-DIN', Helvetica, Arial, sans-serif;
+    font-size: 24px;
+    line-height: 30px;
+}
+
+.constellation-container{
+    position: relative;
+    height: 30px;
+    margin:10px;
+}
+
+.constellation-name {
+    display: inline-block;
+    text-align: right;
+    height: 30px;
+    vertical-align: middle;
+    transition: background-color 0.2s ease-in-out;
+    padding: 5px;
+    user-select: none;
+}
+
+.constellation-name:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+}
+
+.constellation-color {
+    display: inline-block;
+    width: 45px;
+    height: 45px;
+    vertical-align: middle;
+    border: 5px solid #222;
+    box-sizing: border-box;
+}
+
+#constellation-info {
+    display: none;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 550px;
+    padding: 10px;
+    font-family: 'D-DIN', Helvetica, Arial, sans-serif;
+    color: #fff;
+    background-color: #141414;
+    box-shadow: 10px 10px 5px 0 rgba(10, 10, 10, 0.3);
+    transition: opacity 0.2s ease-in-out;
+}
+
+#constellation-info-header-left{
+    display: inline-block;
+    width: 300px;
+    height: 32px;
+    vertical-align: bottom;
+    font-size: 18px;
+    font-weight: bold;
+    line-height: 32px;
+}
+
+#constellation-info-header-right{
+    display: inline-block;
+    width: 190px;
+    height: 32px;
+    vertical-align: bottom;
+    text-align: right;
+    font-size: 12px;
+    line-height: 40px;
+}
+
+#constellation-info-bonus-lablel{
+    position: relative;
+    display: inline-block;
+    height: 20px;
+    vertical-align: bottom;
+    padding-bottom: 2px;
+    font-size: 14px;
+    line-height: 20px;
+    text-align: center;
+    border: 1px solid #141414;
+    width: 70px;
+}
+
+#constellation-info-bonus-val{
+    width: 70px;
+    font-size: 56px;
+    font-weight: bold;
+    line-height: 70px;
+
+}
+
+#constellation-info-hexes-label{
+    position: relative;
+    height: 50px;
+    width:550px;
+    font-size: 18px;
+    font-weight: bold;
+    line-height: 70px;
+}
+
+#constellation-info-hexes-val{
+    position: relative;
+    width: 550px;
+    font-size: 14px;
+}
+
 #viewer {
     position: fixed;
     top: 0;

--- a/html/scripts/utils.js
+++ b/html/scripts/utils.js
@@ -117,7 +117,15 @@ function fetchSheets(urls) {
         .then(val => {
             return val === ':(' ? ':(' : tsvJSON(val);
         });
-    return Promise.all([PlanetMap, SectorObjects, FactionTracker, AssetTracker]);
+    let ConstellationTracker = fetch(fixURL(urls['Constellations']))
+        .then(handleErrors)
+        .then(val => {
+            return val === ':(' ? ':(' : val.text();
+        })
+        .then(val => {
+            return val === ':(' ? ':(' : tsvJSON(val);
+        });
+    return Promise.all([PlanetMap, SectorObjects, FactionTracker, AssetTracker, ConstellationTracker]);
 }
 
 function mapFromSheets(sheets, params) {

--- a/html/scripts/utils.js
+++ b/html/scripts/utils.js
@@ -74,7 +74,7 @@ function fetchURLs(url) {
                 return new Promise(resolve => {
                     let urls = {};
                     val.forEach(row => {
-                        if (['FactionTracker', 'AssetTracker', 'PlanetMap', 'SectorObjects'].includes(row['Tab'])) {
+                        if (['FactionTracker', 'AssetTracker', 'PlanetMap', 'SectorObjects','Constellations'].includes(row['Tab'])) {
                             urls[row['Tab']] = row['Publishing Link'];
                         }
                     });


### PR DESCRIPTION
Added functionality to read constellation details from the google sheet and display on the sector map, with constellations colored based on the hex code of the faction it belongs to. Also added side bar for constellation name and details. Tested with local copies of map sheet data.